### PR TITLE
Update InitializeDTF and ZDT.p.toLocaleString

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -51,4 +51,145 @@
       The complexity of maintaining such invariants is why it is recommended that implementations maintain a fully consistent copy of the IANA Time Zone Database for the lifetime of each agent.
     </p>
   </emu-clause>
+
+  <emu-clause id="sup-temporal.zoneddatetime.prototype.tolocalestring">
+    <h1>Temporal.ZonedDateTime.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
+    <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.zoneddatetime.prototype.tolocalestring"></emu-xref>.</p>
+    <p>
+      This method performs the following steps when called:
+    </p>
+    <emu-alg>
+      1. Let _zonedDateTime_ be the *this* value.
+      1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
+      1. Let _dateTimeFormat_ be ! OrdinaryCreateFromConstructor(%DateTimeFormat%, %DateTimeFormat.protoytpe%, « [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]], [[TimeZoneName]], [[HourCycle]], [[Pattern]], [[BoundFormat]] »).
+      1. Let _timeZone_ be ? ToTemporalTimeZoneIdentifier(_zonedDateTime_.[[TimeZone]]).
+      1. If IsTimeZoneOffsetString(_timeZone_) is *true*, throw a *RangeError* exception.
+      1. Let _timeZoneIdentifierRecord_ be GetAvailableTimeZoneIdentifier(_timeZone_).
+      1. If _timeZoneIdentifierRecord_ is ~empty~, throw a RangeError exception.
+      1. Set _timeZone_ to _timeZoneIdentifierRecord_.[[<del>PrimaryIdentifier</del><ins>Identifier</ins>]].
+      1. Perform ? InitializeDateTimeFormat(_dateTimeFormat_, _locales_, _options_, _timeZone_).
+      1. Let _calendar_ be ? ToTemporalCalendarIdentifier(_zonedDateTime_.[[Calendar]]).
+      1. If _calendar_ is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then
+        1. Throw a *RangeError* exception.
+      1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
+      1. Return ? FormatDateTime(_dateTimeFormat_, _instant_).
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-initializedatetimeformat" aoid="InitializeDateTimeFormat">
+    <h1>InitializeDateTimeFormat ( _dateTimeFormat_, _locales_, _options_ [ , _toLocaleStringTimeZone_ ] )</h1>
+
+    <p>
+      The abstract operation InitializeDateTimeFormat accepts the arguments _dateTimeFormat_ (which must be an object), _locales_, and _options_.
+      It initializes _dateTimeFormat_ as a DateTimeFormat object.
+      If an additional _toLocaleStringTimeZone_ argument is provided (which, if present, must be a canonical time zone name string), the time zone will be overridden and some adjustments will be made to the defaults in order to implement the behaviour of `Temporal.ZonedDateTime.prototype.toLocaleString`.
+      This abstract operation functions as follows:
+    </p>
+
+    <p>
+      The following algorithm refers to the `type` nonterminal from <a href="https://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
+    </p>
+
+    <emu-alg>
+      1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+      1. Let _opt_ be a new Record.
+      1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
+      1. Set _opt_.[[localeMatcher]] to _matcher_.
+      1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, *"string"*, *undefined*, *undefined*).
+      1. If _calendar_ is not *undefined*, then
+        1. If _calendar_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
+      1. Set _opt_.[[ca]] to _calendar_.
+      1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
+      1. If _numberingSystem_ is not *undefined*, then
+        1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
+      1. Set _opt_.[[nu]] to _numberingSystem_.
+      1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
+      1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, « *"h11"*, *"h12"*, *"h23"*, *"h24"* », *undefined*).
+      1. If _hour12_ is not *undefined*, then
+        1. Set _hourCycle_ to *null*.
+      1. Set _opt_.[[hc]] to _hourCycle_.
+      1. Let _localeData_ be %DateTimeFormat%.[[LocaleData]].
+      1. Let _r_ be ResolveLocale(%DateTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %DateTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
+      1. Set _dateTimeFormat_.[[Locale]] to _r_.[[locale]].
+      1. Let _resolvedCalendar_ be _r_.[[ca]].
+      1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.
+      1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
+      1. Let _dataLocale_ be _r_.[[dataLocale]].
+      1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+      1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
+      1. If _hour12_ is *true*, then
+        1. If _hcDefault_ is *"h11"* or *"h23"*, let _hc_ be *"h11"*. Otherwise, let _hc_ be *"h12"*.
+      1. Else if _hour12_ is *false*, then
+        1. If _hcDefault_ is *"h11"* or *"h23"*, let _hc_ be *"h23"*. Otherwise, let _hc_ be *"h24"*.
+      1. Else,
+        1. Assert: _hour12_ is *undefined*.
+        1. Let _hc_ be _r_.[[hc]].
+        1. If _hc_ is *null*, set _hc_ to _hcDefault_.
+      1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
+      1. If _timeZone_ is *undefined*, then
+        1. If _toLocaleStringTimeZone_ is present, then
+          1. Set _timeZone_ to _toLocaleStringTimeZone_.
+        1. Else,
+          1. Set _timeZone_ to SystemTimeZoneIdentifier().
+      1. Else,
+        1. If _toLocaleStringTimeZone_ is present, throw a *TypeError* exception.
+        1. Set _timeZone_ to ? ToString(_timeZone_).
+        1. Let _timeZoneIdentifierRecord_ be GetAvailableTimeZoneIdentifier(_timeZone_).
+        1. If _timeZoneIdentifierRecord_ is ~empty~, then
+          1. Throw a *RangeError* exception.
+        1. Set _timeZone_ to _timeZoneIdentifierRecord_.[[<del>PrimaryIdentifier</del><ins>Identifier</ins>]].
+      1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
+      1. Let _formatOptions_ be a new Record.
+      1. Set _formatOptions_.[[hourCycle]] to _hc_.
+      1. Let _hasExplicitFormatComponents_ be *false*.
+      1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
+        1. Let _prop_ be the name given in the Property column of the row.
+        1. If _prop_ is *"fractionalSecondDigits"*, then
+          1. Let _value_ be ? GetNumberOption(_options_, *"fractionalSecondDigits"*, 1, 3, *undefined*).
+        1. Else,
+          1. Let _values_ be a List whose elements are the strings given in the Values column of the row.
+          1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, _values_, *undefined*).
+        1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
+        1. If _value_ is not *undefined*, then
+          1. Set _hasExplicitFormatComponents_ to *true*.
+      1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, « *"basic"*, *"best fit"* », *"best fit"*).
+      1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, *"string"*, « *"full"*, *"long"*, *"medium"*, *"short"* », *undefined*).
+      1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.
+      1. Let _timeStyle_ be ? GetOption(_options_, *"timeStyle"*, *"string"*, « *"full"*, *"long"*, *"medium"*, *"short"* », *undefined*).
+      1. Set _dateTimeFormat_.[[TimeStyle]] to _timeStyle_.
+      1. Let _expandedOptions_ be a copy of _formatOptions_.
+      1. Let _needDefaults_ be *true*.
+      1. For each element _field_ of « *"weekday"*, *"year"*, *"month"*, *"day"*, *"hour"*, *"minute"*, *"second"* » in List order, do
+        1. If _expandedOptions_.[[&lt;_field_&gt;]] is not *undefined*, then
+          1. Set _needDefaults_ to *false*.
+      1. If _needDefaults_ is *true*, then
+        1. For each element _field_ of « *"year"*, *"month"*, *"day"*, *"hour"*, *"minute"*, *"second"* » in List order, do
+          1. Set _expandedOptions_.[[&lt;_field_&gt;]] to *"numeric"*.
+      1. Let _bestFormat_ be GetDateTimeFormatPattern(_dateStyle_, _timeStyle_, _matcher_, _expandedOptions_, _dataLocaleData_, _hc_, _resolvedCalendar_, _hasExplicitFormatComponents_).
+      1. Set _dateTimeFormat_.[[Pattern]] to _bestFormat_.[[pattern]].
+      1. Set _dateTimeFormat_.[[RangePatterns]] to _bestFormat_.[[rangePatterns]].
+      1. For each row in <emu-xref href="#table-temporal-patterns"></emu-xref>, except the header row, in table order, do
+        1. Let _limitedOptions_ be a new Record.
+        1. Let _needDefaults_ be *true*.
+        1. Let _fields_ be the list of fields in the Supported fields column of the row.
+        1. For each field _field_ of _formatOptions_, do
+          1. If _field_ is in _fields_, then
+            1. Set _needDefaults_ to *false*.
+            1. Set _limitedOptions_.[[&lt;_field_&gt;]] to _formatOptions_.[[&lt;_field_&gt;]].
+        1. If _needDefaults_ is *true*, then
+          1. Let _defaultFields_ be the list of fields in the Default fields column of the row.
+          1. If the Pattern column of the row is [[TemporalInstantPattern]], and _toLocaleStringTimeZone_ is present, append [[timeZoneName]] to _defaultFields_.
+          1. For each element _field_ of _defaultFields_, do
+            1. If _field_ is [[timeZoneName]], then
+              1. Let _defaultValue_ be *"short"*.
+            1. Else,
+              1. Let _defaultValue_ be *"numeric"*.
+            1. Set _limitedOptions_.[[&lt;_field_&gt;]] to _defaultValue_.
+        1. Let _bestFormat_ be GetDateTimeFormatPattern(_dateStyle_, _timeStyle_, _matcher_, _limitedOptions_, _dataLocaleData_, _hc_, _resolvedCalendar_, _hasExplicitFormatComponents_).
+        1. If _bestFormat_ does not have any fields that are in _fields_, then
+          1. Set _bestFormat_ to *null*.
+        1. Set _dateTimeFormat_'s internal slot whose name is the Pattern column of the row to _bestFormat_.
+      1. Return _dateTimeFormat_.
+    </emu-alg>
+  </emu-clause>
 </emu-clause>

--- a/spec/temporal-biblio.json
+++ b/spec/temporal-biblio.json
@@ -26,6 +26,46 @@
         "type": "op",
         "aoid": "ToTemporalTimeZoneIdentifier",
         "id": "sec-totemporaltimezoneidentifier"
+      },
+      {
+        "type": "op",
+        "aoid": "ToTemporalCalendarIdentifier",
+        "id": "sec-totemporalcalendaridentifier"
+      },
+      {
+        "type": "op",
+        "aoid": "CreateTemporalInstant",
+        "id": "sec-createtemporalinstant"
+      },
+      {
+        "type": "op",
+        "aoid": "FormatDateTime",
+        "id": "sec-formatdatetime"
+      },
+      {
+        "type": "op",
+        "aoid": "SystemTimeZoneIdentifier",
+        "id": "sec-systemtimezoneidentifier"
+      },
+      {
+        "type": "op",
+        "aoid": "GetDateTimeFormatPattern",
+        "id": "sec-getdatetimeformatpattern"
+      },
+      {
+        "type": "op",
+        "aoid": "GetOption",
+        "id": "sec-getoption"
+      },
+      {
+        "type": "clause",
+        "number": "Supported fields for Temporal patterns",
+        "id": "table-temporal-patterns"
+      },
+      {
+        "type": "clause",
+        "number": "Temporal.ZonedDateTime.prototype.toLocaleString",
+        "id": "sec-temporal.zoneddatetime.prototype.tolocalestring"
       }
     ]
   }


### PR DESCRIPTION
Remove canonicalization from `InitializeDateTimeFormat` and (the overridden 402 version of) `ZonedDateTime.p.toLocaleString`. Doing this requires a one-line spec change in each.