### PR TITLE
Update polyfill and tests

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -20,8 +20,8 @@ The full surface area of this proposal is expected to be covered by Test262 test
 - [x] DONE Add lightweight "Demitasse" tests in [test/canonicaltz.mjs](./test/canonicaltz.mjs) that cover this proposal's full surface area
 - [x] DONE Fix 15 existing Test262 tests that were broken by this proposal, because they assumed that time zone identifiers are always canonicalized
 - [x] DONE Open a Test262 draft PR
-- [ ] Migrate `Temporal.TimeZone.p.equals` (the only new API in this proposal) Demitasse tests to Test262
-- [ ] Migrate `Temporal.TimeZone` Demitasse tests to Test262
+- [x] Migrate `Temporal.TimeZone.p.equals` (the only new API in this proposal) Demitasse tests to Test262
+- [x] Migrate `Temporal.TimeZone` Demitasse tests to Test262
 - [ ] Migrate `Temporal.ZonedDateTime` Demitasse tests to Test262
 - [ ] Migrate `Intl.DateTimeFormat` Demitasse tests to Test262
 - [ ] Remove Demitasse tests from this repo and from CI workflows

--- a/polyfill/polyfill.diff
+++ b/polyfill/polyfill.diff
@@ -21,10 +21,10 @@ index 244067cb..d4b6f741 100644
      getOffsetStringFor(instant: Temporal.Instant | string): string;
      getPlainDateTimeFor(instant: Temporal.Instant | string, calendar?: CalendarLike): Temporal.PlainDateTime;
 diff --git a/polyfill/lib/ecmascript.mjs b/polyfill/lib/ecmascript.mjs
-index 6b2a318d..bf86bda9 100644
+index adbb9d2e..47803e67 100644
 --- a/polyfill/lib/ecmascript.mjs
 +++ b/polyfill/lib/ecmascript.mjs
-@@ -370,7 +370,7 @@ export function ParseTemporalTimeZone(stringIdent) {
+@@ -371,7 +371,7 @@ export function ParseTemporalTimeZone(stringIdent) {
      if (IsTimeZoneOffsetString(tzName)) return CanonicalizeTimeZoneOffsetString(tzName);
      const record = GetAvailableNamedTimeZoneIdentifier(tzName);
      if (!record) throw new RangeError(`Unrecognized time zone ${tzName}`);
@@ -33,7 +33,7 @@ index 6b2a318d..bf86bda9 100644
    }
    if (z) return 'UTC';
    // if !tzName && !z then offset must be present
-@@ -2118,7 +2118,16 @@ export function TimeZoneEquals(one, two) {
+@@ -2119,7 +2119,16 @@ export function TimeZoneEquals(one, two) {
    if (one === two) return true;
    const tz1 = ToTemporalTimeZoneIdentifier(one);
    const tz2 = ToTemporalTimeZoneIdentifier(two);
@@ -102,10 +102,36 @@ index 1a593c7f..06de9d5f 100644
      }
  
      const formatter = new DateTimeFormat(locales, optionsCopy);
+diff --git a/polyfill/package.json b/polyfill/package.json
+index 0cc84100..94128825 100644
+--- a/polyfill/package.json
++++ b/polyfill/package.json
+@@ -10,7 +10,7 @@
+     "test": "node --loader ./test/resolve.source.mjs ./test/all.mjs",
+     "test-cookbook": "npm run build && TEST=all npm run test-cookbook-one && TEST=stockExchangeTimeZone npm run test-cookbook-one",
+     "test-cookbook-one": "node --loader ./test/resolve.cookbook.mjs ../docs/cookbook/$TEST.mjs",
+-    "test262": "npm run build262 && TIMEOUT=30000 node runtest262.mjs",
++    "test262": "npm run build262 && node runtest262.mjs",
+     "codecov:test262": "./ci_codecov_test262.sh",
+     "build": "rollup -c rollup.config.js --bundleConfigAsCjs",
+     "build262": "TEST262=1 rollup -c rollup.config.js --bundleConfigAsCjs",
+diff --git a/polyfill/runtest262.mjs b/polyfill/runtest262.mjs
+index e944bb6f..f4d90ecd 100644
+--- a/polyfill/runtest262.mjs
++++ b/polyfill/runtest262.mjs
+@@ -4,7 +4,7 @@ const result = runTest262({
+   test262Dir: 'test262',
+   polyfillCodeFile: 'script.js',
+   expectedFailureFiles: ['test/expected-failures.txt'],
+-  timeoutMsecs: process.env.TIMEOUT,
++  timeoutMsecs: process.env.TIMEOUT || 30000,
+   testGlobs: process.argv.slice(2)
+ });
+ 
 diff --git a/polyfill/test262 b/polyfill/test262
-index 3e858ef0..be8f7e90 160000
+index 3e858ef0..ad8a846b 160000
 --- a/polyfill/test262
 +++ b/polyfill/test262
 @@ -1 +1 @@
 -Subproject commit 3e858ef02d2eda1e1e7eeff89ad7deeaf99d2766
-+Subproject commit be8f7e90217da86f3949d8ece80dc5ae3d990165
++Subproject commit ad8a846bb8fb14912e755a4d4f2616e37f6eaa41

--- a/refresh_polyfill_code.sh
+++ b/refresh_polyfill_code.sh
@@ -21,6 +21,5 @@ if [ -n "$CI" ]; then
   fi
 else
   # When running outside CI, validate that the polyfill still builds
-  cd tenporal/polyfill
   npm run build
 fi


### PR DESCRIPTION
Updates the polyfill to run tests directly from the `temporal` submodule, which now points to the `canonical-tz-polyfill` branch of the proposal-temporal repo. As before, the actual polyfill changes (which are minimal) are in polyfill/polyfill.diff

Updating to the latest temporal branch also updates its Test262 submodule to the latest commits from https://github.com/tc39/test262/pull/3837.