### PR TITLE
Add tests for ZonedDateTime and Intl.DTF

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -22,8 +22,8 @@ The full surface area of this proposal is expected to be covered by Test262 test
 - [x] DONE Open a Test262 draft PR
 - [x] Migrate `Temporal.TimeZone.p.equals` (the only new API in this proposal) Demitasse tests to Test262
 - [x] Migrate `Temporal.TimeZone` Demitasse tests to Test262
-- [ ] Migrate `Temporal.ZonedDateTime` Demitasse tests to Test262
-- [ ] Migrate `Intl.DateTimeFormat` Demitasse tests to Test262
+- [x] Migrate `Temporal.ZonedDateTime` Demitasse tests to Test262
+- [x] Migrate `Intl.DateTimeFormat` Demitasse tests to Test262
 - [ ] Remove Demitasse tests from this repo and from CI workflows
 
 ### How to run tests

--- a/polyfill/polyfill.diff
+++ b/polyfill/polyfill.diff
@@ -129,9 +129,9 @@ index e944bb6f..f4d90ecd 100644
  });
  
 diff --git a/polyfill/test262 b/polyfill/test262
-index 3e858ef0..ad8a846b 160000
+index 3e858ef0..041e65e3 160000
 --- a/polyfill/test262
 +++ b/polyfill/test262
 @@ -1 +1 @@
 -Subproject commit 3e858ef02d2eda1e1e7eeff89ad7deeaf99d2766
-+Subproject commit ad8a846bb8fb14912e755a4d4f2616e37f6eaa41
++Subproject commit 041e65e336e35f1989ec5f0fcf8b2ac745837ab0

--- a/refresh_polyfill_code.sh
+++ b/refresh_polyfill_code.sh
@@ -3,7 +3,15 @@
 # Get latest contents of canonical-tz-polyfill branch of proposal-temporal
 git submodule update --init --remote --force --recursive
 
-# Regenerate the patch file of the (few) changes in this proposal's polyfill
+# Submodules were updated to detached heads. Undetach them by switching to the
+# the correct branch for each.
+cd temporal
+git switch canonical-tz-polyfill
+cd polyfill/test262
+git switch proposal-canonical-tz-tests
+cd ../..
+
+# Regenerate the patch file of the (few) changes in this proposal's polyfill.
 # The polyfill changes are in one commit at HEAD of the submodule's branch.
 cd temporal
 git diff HEAD~1 > ../polyfill/polyfill.diff


### PR DESCRIPTION
Add Test262 coverage for this proposal's changes to Temporal.ZonedDateTime and Intl.DateTimeFormat.

Note that a few of the new tests won't be run in CI until https://github.com/js-temporal/temporal-test262-runner/pull/14 is merged, published to npm, and this PR is updated to include the new rev of [@js-temporal/test262-test-runner](https://github.com/js-temporal/temporal-test262-runner).