### PR TITLE
Editorial: refactor early returns in TimeZoneEquals

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -150,10 +150,8 @@
           1. Let _timeZoneTwo_ be ? ToTemporalTimeZoneIdentifier(_two_).
           1. If _timeZoneOne_ is _timeZoneTwo_, return *true*.
           1. <ins>Let _recordOne_ be GetAvailableNamedTimeZoneIdentifier(_timeZoneOne_).</ins>
-          1. <ins>If _recordOne_ is ~empty~, return *false*.</ins>
           1. <ins>Let _recordTwo_ be GetAvailableNamedTimeZoneIdentifier(_timeZoneTwo_).</ins>
-          1. <ins>If _recordTwo_ is ~empty~, return *false*.</ins>
-          1. <ins>If _recordOne_.[[PrimaryIdentifier]] is _recordTwo_.[[PrimaryIdentifier]], return *true*.</ins>
+          1. <ins>If _recordOne_ is not ~empty~ and _recordTwo_ is not ~empty~ and _recordOne_.[[PrimaryIdentifier]] is _recordTwo_.[[PrimaryIdentifier]], return *true*.</ins>
           1. Return *false*.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
This PR consolidates early returns from TimeZoneEquals, as suggested in https://github.com/tc39/proposal-canonical-tz/issues/35#issuecomment-1599484497.