### PR TITLE
Add ToTemporalTimeZoneSlotValue in TimeZone.p.equals

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -42,13 +42,14 @@
 
     <ins class="block">
     <emu-clause id="sec-temporal.timezone.prototype.equals">
-      <h1>Temporal.TimeZone.prototype.equals ( _other_ )</h1>
+      <h1>Temporal.TimeZone.prototype.equals ( _timeZoneLike_ )</h1>
       <p>
         This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
+        1. Let _other_ be ? ToTemporalTimeZoneSlotValue(_timeZoneLike_).
         1. Return ? TimeZoneEquals(_timeZone_, _other_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Without this, we will fail some assertions in the case of a non-string argument, or a string argument that's not a valid time zone identifier. In the plain object case, we'll also miss some Has calls in ObjectImplementsTemporalTimeZoneProtocol.

Closes: #41